### PR TITLE
Added additional verification for disposal of credentials

### DIFF
--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/HttpMethodDirector.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/HttpMethodDirector.java
@@ -224,6 +224,8 @@ class HttpMethodDirector {
 
             } // end of retry loop
         } finally {
+            method.getHostAuthState().getAuthScheme().cleanup();
+
             if (conn != null) {
                 conn.setLocked(false);
             }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/AuthScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/AuthScheme.java
@@ -79,6 +79,11 @@ public interface AuthScheme {
      */
     public boolean supportsCredentials(Credentials credentials);
 
+    /*
+     * Performs cleanup operations that might be required, such as the disposing of handles
+     */
+    public void cleanup();
+
     /**
      * Processes the given challenge token. Some authentication schemes may
      * involve multiple challenge-response exchanges. Such schemes must be able

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/CookieAuthScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/CookieAuthScheme.java
@@ -15,6 +15,11 @@ public class CookieAuthScheme implements AuthScheme {
     }
 
     @Override
+    public void cleanup() {
+        //No disposing of credentials needed
+    }
+
+    @Override
     public void processChallenge(final String challenge) throws MalformedChallengeException {
         throw new MalformedChallengeException("Cookie authentication is not challenge/response"); //$NON-NLS-1$
     }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/JwtAuthScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/JwtAuthScheme.java
@@ -22,6 +22,11 @@ public class JwtAuthScheme extends AuthorizationHeaderScheme {
     }
 
     @Override
+    public void cleanup() {
+        //No disposing of credentials needed
+    }
+
+    @Override
     public void processChallenge(final String challenge) throws MalformedChallengeException {
         complete = true;
     }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/NTLMScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/NTLMScheme.java
@@ -70,6 +70,16 @@ public class NTLMScheme extends AuthorizationHeaderScheme implements AuthScheme 
         return supportsCredentials(credentials.getClass());
     }
 
+    @Override
+    public void cleanup() {
+        if(ntlmClient != null) {
+            ntlmClient.dispose();
+
+            ntlmClient = null;
+            inputToken = null;
+        }
+    }
+
     public static boolean supportsCredentials(final Class<?> credentialClass) {
         if (credentialClass == null || !isSupported()) {
             return false;
@@ -221,11 +231,7 @@ public class NTLMScheme extends AuthorizationHeaderScheme implements AuthScheme 
             if (ntlmClient.isComplete()) {
                 status = STATUS_COMPLETE;
 
-                /* Clean up */
-                ntlmClient.dispose();
-
-                ntlmClient = null;
-                inputToken = null;
+                cleanup();
             } else {
                 status = STATUS_EXCHANGING;
             }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/NegotiateScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/NegotiateScheme.java
@@ -70,6 +70,16 @@ public class NegotiateScheme extends AuthorizationHeaderScheme implements AuthSc
         return supportsCredentials(credentials.getClass());
     }
 
+    @Override
+    public void cleanup() {
+        if(negotiateClient != null) {
+            negotiateClient.dispose();
+
+            negotiateClient = null;
+            inputToken = null;
+        }
+    }
+
     public static boolean supportsCredentials(final Class<?> credentialClass) {
         if (credentialClass == null || !isSupported()) {
             return false;
@@ -222,11 +232,7 @@ public class NegotiateScheme extends AuthorizationHeaderScheme implements AuthSc
             if (negotiateClient.isComplete()) {
                 status = STATUS_COMPLETE;
 
-                /* Clean up */
-                negotiateClient.dispose();
-
-                negotiateClient = null;
-                inputToken = null;
+                cleanup();
             } else {
                 status = STATUS_EXCHANGING;
             }


### PR DESCRIPTION
Previously, if some exception happened while in the for loop of
HTTPMethodDirector.executeMethod, it could ocasionally exit without
releasing previously acquired handles from NTLM and Negotiate. This
change ensures the releasing of the handles by calling a cleanup method
on the finally, outside of the for loop.